### PR TITLE
feat: add `toAutoNotify` field in models/Post.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 3.1.0 (2020-04-20)
+#### Commits
+* [[`49c1310f58`](https://github.com/twreporter/keystone-plate/commit/49c1310f58)] - **feat**: add `toAutoNotify` field in models/Post.js (nickhsine)
+
 ### 3.0.2 (2020-03-30)
 
 ### Commits

--- a/models/Post.js
+++ b/models/Post.js
@@ -87,6 +87,7 @@ Post.add({
   og_title: { label: '分享標題', type: String, require: false},
   og_description: { label: '分享說明', type: String, require: false},
   og_image: { label: '分享縮圖', type: Types.ImageRelationship, ref: 'Image' },
+  toAutoNotify: { label: '自動推播', type: Boolean, default: true},
   is_external: { label: '另開新頁', type: Boolean, index: true },
   isFeatured: { label: '置頂', type: Boolean, index: true },
   preview: { type: Types.Preview },


### PR DESCRIPTION
### Feature Description
For editors, they want Notification System to send notifications automatically by default, and turn off automation conditionally.

Therefore, we let editors to control automation via editing the post in the Keystone.

The posts with `toAutoNotify: true` will be automatically sent by Notification System.

### Reference
- https://github.com/twreporter/Wiki/tree/master/notification-publish#changes
- https://github.com/twreporter/cronjob/commit/0224d7b5a91c37f4778a6b2cdff024dc3227ef0a#diff-3138111ff197023d826f36a90bea675bR43