### PR TITLE
chore: bump version to v3.2.5-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 3.2.5-rc.0
+
+#### Notable Changes
+- feat
+  - enable mongo session store([#215](https://github.com/twreporter/plate/pull/215), [#216](https://github.com/twreporter/plate/pull/216))
+- docs
+  - add release-test-item([#149](https://github.com/twreporter/plate/pull/149))
+
+#### Commits
+* [[`5310581ca3`](https://github.com/twreporter/keystone-plate/commit/5310581ca3)] - **feat**: define the options of session store (Ching-Yang, Tseng)
+* [[`b575395843`](https://github.com/twreporter/keystone-plate/commit/b575395843)] - **feat**: use connect-mongo as express-session storage (Ching-Yang, Tseng)
+* [[`083e9490f7`](https://github.com/twreporter/keystone-plate/commit/083e9490f7)] - Merge pull request #149 from nickhsine/release-test-items (babygoat)
+
 ### 3.2.4 (2020-12-09)
 
 #### Notable Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystone-plate",
-  "version": "3.2.4",
+  "version": "3.2.5-rc.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^2.6.0",
     "@twreporter/errors": "^1.1.0",
-    "@twreporter/keystone": "0.9.3",
+    "@twreporter/keystone": "0.9.4-rc.2",
     "@twreporter/keystone-plugin-client": "1.0.7",
     "@twreporter/keystone-plugin-socketio": "1.0.7",
     "babel-core": "^6.4.5",


### PR DESCRIPTION
This patch bumps the version to v3.2.5-rc.0.