### PR TITLE
chore: bump @twreporter/keystone to v0.9.4-rc.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@godaddy/terminus": "^4.9.0",
     "@google-cloud/pubsub": "^2.6.0",
     "@twreporter/errors": "^1.1.0",
-    "@twreporter/keystone": "0.9.4-rc.5",
+    "@twreporter/keystone": "0.9.4-rc.7",
     "@twreporter/keystone-plugin-client": "1.0.7",
     "@twreporter/keystone-plugin-socketio": "1.0.7",
     "babel-core": "^6.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@twreporter/draft-js@0.11.8-rc.1":
-  version "0.11.8-rc.1"
-  resolved "https://registry.yarnpkg.com/@twreporter/draft-js/-/draft-js-0.11.8-rc.1.tgz#c85c5272dbb5523b1e7b52c6251aff50ddb4dff1"
-  integrity sha512-9D4MsEiQkQx/5QdNeU6ExSPW58+4tkuX/zkrqItDYb+O3Rmiqd5+KhGOZjqr1/b31Eyp4mvTgbx+mxNh2via9w==
+"@twreporter/draft-js@0.11.8-rc.2":
+  version "0.11.8-rc.2"
+  resolved "https://registry.yarnpkg.com/@twreporter/draft-js/-/draft-js-0.11.8-rc.2.tgz#8347ab69784d20d89568d2d022557cdb8a37352c"
+  integrity sha512-MMAGLjQlQZhV7hguwYpwxCtDtHsIJ7OkveGlVtVypcPyLX2iDf0QDqkTJD0/oyA0v/h8LDpOyMASNHUyf0kHcw==
   dependencies:
     fbjs "^2.0.0"
     immutable "~3.7.4"
@@ -1238,13 +1238,13 @@
     lodash "^4.17.15"
     socket.io "^2.0.4"
 
-"@twreporter/keystone@0.9.4-rc.5":
-  version "0.9.4-rc.5"
-  resolved "https://registry.yarnpkg.com/@twreporter/keystone/-/keystone-0.9.4-rc.5.tgz#f26a28ba619c8467577b80b93dd6a9e16b9afaed"
-  integrity sha512-HXZksOmhOGsnsttGAYQU7Bfz65z5iaScWMp3X0EtUW8Lu+Cy9tfdrUsI9Pbn967iafX6u6o50Gkt3kfW1M70RA==
+"@twreporter/keystone@0.9.4-rc.7":
+  version "0.9.4-rc.7"
+  resolved "https://registry.yarnpkg.com/@twreporter/keystone/-/keystone-0.9.4-rc.7.tgz#968f9e3c26e545248a9de541ec5a047882fee8c6"
+  integrity sha512-rySDl9v2bCrNksxKk/8Ev1KKABRh7fKHAeS5jZjc5p0dhJGbAhASCJiQRQ7GIKG+5jlXFU7Ug2s/+G3PerbuUg==
   dependencies:
     "@google-cloud/storage" "~1.7.0"
-    "@twreporter/draft-js" "0.11.8-rc.1"
+    "@twreporter/draft-js" "0.11.8-rc.2"
     "@twreporter/react-article-components" "0.2.0"
     async "1.5.2"
     asyncdi "1.1.0"


### PR DESCRIPTION
This patch bumps the version of @twreprter/keystone to v0.9.4-rc.7.