### PR TITLE
Revert "refactor: change session key to `keystone.sid`"

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -85,9 +85,6 @@ exports.options = {
   'cloudinary config': 'cloudinary://333779167276662:_8jbSi9FB3sWYrfimcl8VKh34rI@keystone-demo',
   'auto update': true,
   'session': true,
-  'session options': {
-    key: 'keystone.sid',
-  },
   'session store': 'mongo',
   'session store options':{
     autoRemove: 'interval',
@@ -95,7 +92,6 @@ exports.options = {
     touchAfter: 0,
     ttl: 14 * 24 * 60 * 60 * 1000,
   },
-  'signout url': '/signout',
   'auth': ${auth},
   'user model': 'User',
   'cookie secret': '${cookieSecret}',

--- a/config-for-docker-build.js
+++ b/config-for-docker-build.js
@@ -18,9 +18,6 @@ exports.options = {
   'cloudinary config': 'cloudinary://333779167276662:_8jbSi9FB3sWYrfimcl8VKh34rI@keystone-demo',
   'auto update': true,
   'session': true,
-  'session options': {
-    key: 'keystone.sid',
-  },
   'session store': 'mongo',
   'session store options': {
     autoRemove: 'interval',
@@ -28,7 +25,6 @@ exports.options = {
     touchAfter: process.env.KEYSTONE_SESSION_TOUCH_AFTER ? parseInt(process.env.KEYSTONE_SESSION_TOUCH_AFTER, 10) : 0,
     ttl: process.env.KEYSTONE_SESSION_TTL ? parseInt(process.env.KEYSTONE_SESSION_TTL, 10) : 14 * 24 * 60 * 60,
   },
-  'signout url': 'signout',
   'auth': true,
   'user model': 'User',
   'cookie secret': process.env.KEYSTONE_COOKIE_SECRET,


### PR DESCRIPTION
Reverts twreporter/plate#256

I accidentally mixed up the signout feature into #256. This patch reverts the commit and will commit the original target commit again later.