### PR TITLE
feat: add signout page

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -95,6 +95,7 @@ exports.options = {
     touchAfter: 0,
     ttl: 14 * 24 * 60 * 60 * 1000,
   },
+  'signout url': '/signout',
   'auth': ${auth},
   'user model': 'User',
   'cookie secret': '${cookieSecret}',

--- a/config-for-docker-build.js
+++ b/config-for-docker-build.js
@@ -28,6 +28,7 @@ exports.options = {
     touchAfter: process.env.KEYSTONE_SESSION_TOUCH_AFTER ? parseInt(process.env.KEYSTONE_SESSION_TOUCH_AFTER, 10) : 0,
     ttl: process.env.KEYSTONE_SESSION_TTL ? parseInt(process.env.KEYSTONE_SESSION_TTL, 10) : 14 * 24 * 60 * 60,
   },
+  'signout url': '/signout',
   'auth': true,
   'user model': 'User',
   'cookie secret': process.env.KEYSTONE_COOKIE_SECRET,


### PR DESCRIPTION
This patch set the `signout url` configuration to enable the builtin
signout feature.

Address [TWREPORTER-121](https://twreporter-org.atlassian.net/browse/TWREPORTER-121)