### PR TITLE
chore: removes build filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,13 +149,7 @@ workflows:
   version: 2
   build_and_push:
     jobs:
-      - build:
-          filters:
-            branches:
-              only:
-                - master
-                - staging
-                - release
+      - build
       - push:
           context: twreporter
           requires:


### PR DESCRIPTION
This patch removes the build filter so that every branch(including pull
request) should be validated before merge.