### PR TITLE
refactor: add 'status' to default columns in topic page

### DIFF
--- a/models/Topic.js
+++ b/models/Topic.js
@@ -33,5 +33,5 @@ Topic.add({
 Topic.relationship({ ref: 'Post', refPath: 'topics' });
 
 transform.toJSON(Topic);
-Topic.defaultColumns = 'name, topic_name|40%, publishedDate|20%';
+Topic.defaultColumns = 'name, topic_name|40%, state|20%, publishedDate|20%';
 Topic.register();


### PR DESCRIPTION
Address https://twreporter-org.atlassian.net/browse/TWREPORTER-348.

This change adds 'status', which stands for publish status of a topic,
to default columns in topic page.