### PR TITLE
feat: apply latest tag on tag.latest_order field

### DIFF
--- a/models/Tag.js
+++ b/models/Tag.js
@@ -1,5 +1,6 @@
 var keystone = require('@twreporter/keystone');
 var transform = require('model-transform');
+const { Types } = keystone.Field
 
 var Tag = new keystone.List('Tag', {
 	autokey: { from: 'name', path: 'key', unique: true },
@@ -7,7 +8,12 @@ var Tag = new keystone.List('Tag', {
 
 Tag.add({
 	name: { label: '標籤名稱', type: String, required: true },
-	latest_order: { label: '最新(順序)', type: Number, noedit: true },
+	latest_order: {
+          type: Types.Tag,
+          label: '最新',
+          noedit: true,
+          dependsOn: { $gt: { latest_order: 0} },
+        },
 });
 
 Tag.relationship({ ref: 'Post', refPath: 'tags' });


### PR DESCRIPTION
- https://app.asana.com/0/1202896150264815/1202959962459829/f
- This patch use new added `tag` field for latest info baesed on `latest_order`. 
  - for new `tag` field, please refer to [keystone #233](https://github.com/twreporter/keystone/pull/233)