### PR TITLE
chore: update Dockerfile. Fix circleci build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,19 @@ RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 ENV TZ=Asia/Taipei
 WORKDIR /usr/src/react
 
+# 使用 archive.debian.org + 忽略過期簽章
 RUN set -x \
-    && sed -i -e 's/deb.debian.org/archive.debian.org/g' \
-           -e 's|security.debian.org|archive.debian.org/|g' \
-           -e '/stretch-updates/d' /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates graphicsmagick imagemagick\
+    && echo 'deb http://archive.debian.org/debian stretch main contrib non-free' > /etc/apt/sources.list \
+    && echo 'deb http://archive.debian.org/debian-security stretch/updates main contrib non-free' >> /etc/apt/sources.list \
+    && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99ignore-check-valid-until \
+    && echo 'Acquire::AllowInsecureRepositories "true";' > /etc/apt/apt.conf.d/99allow-insecure \
+    && echo 'APT::Get::AllowUnauthenticated "true";' > /etc/apt/apt.conf.d/99allow-unauthenticated \
+    && apt-get -o Acquire::AllowInsecureRepositories=true \
+               -o APT::Get::AllowUnauthenticated=true update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       graphicsmagick \
+       imagemagick \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy source files


### PR DESCRIPTION
## Issue
此 PR 嘗試修復 CircleCI [deploy failure](https://app.circleci.com/pipelines/github/twreporter/plate/420/workflows/a875d204-5f6d-4fc7-a218-fca8d34fc324/jobs/853/parallel-runs/0/steps/0-106).

CircleCI 在執行 `Build and push Docker image` 時遇到錯誤，error logs 顯示，更新 debian stretch 時，遇到版本太舊， GPG public key 已經失效的問題。

Commit 的修正方式是 ChatGPT 推薦的 workaround（以不更新 debian 版本為前提），直接忽略 authentication 去下載更新。
